### PR TITLE
FIX: Booster Packs not unlocking when continuing game

### DIFF
--- a/Configs/manifest.json
+++ b/Configs/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "archipelago_randomizer",
 	"name": "Archipelago Randomizer",
-	"version": "0.0.5",
+	"version": "0.0.5-hotfix",
 	"assembly": "StacklandsRandomizer.dll"
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -922,10 +922,7 @@ namespace Stacklands_Randomizer_Mod
             {
                 foreach (string id in ids)
                 {
-                    if (bypassSaveState || !WorldManager.instance.CurrentSave.FoundBoosterIds.Contains(id))
-                    {
-                        UnlockBoosterPack(id);
-                    }
+                    UnlockBoosterPack(id);
                 }
 
                 return !bypassSaveState;

--- a/Patches/QuestManager.cs
+++ b/Patches/QuestManager.cs
@@ -60,9 +60,12 @@ namespace Stacklands_Randomizer_Mod
         [HarmonyPostfix]
         public static void OnSpecialActionComplete_Intercept(string action, CardData card = null)
         {
-            Debug.Log($"{nameof(QuestManager)}.{nameof(QuestManager.SpecialActionComplete)} Postfix!");
-            Debug.Log($"CardData: {card?.Name}");
-            Debug.Log($"Special Action: {action}");
+            if (action != "pause_game") // <- Prevents it constantly printing on pause
+            {
+                Debug.Log($"{nameof(QuestManager)}.{nameof(QuestManager.SpecialActionComplete)} Postfix!");
+                Debug.Log($"CardData: {card?.Name}");
+                Debug.Log($"Special Action: {action}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes
- Updated `HandleItemAsBooster` to ignore checking the `WorldManager.instance.CurrentSave.FoundBoosterIds` as it seems it may not be populated by the time the game loads.