### PR TITLE
Item Handling Rewrite

### DIFF
--- a/Configs/manifest.json
+++ b/Configs/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "archipelago_randomizer",
 	"name": "Archipelago Randomizer",
-	"version": "0.0.5-hotfix",
+	"version": "0.0.6",
 	"assembly": "StacklandsRandomizer.dll"
 }

--- a/Enums/ItemType.cs
+++ b/Enums/ItemType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 
 namespace Stacklands_Randomizer_Mod

--- a/Handlers/ItemHandler.cs
+++ b/Handlers/ItemHandler.cs
@@ -1,0 +1,224 @@
+﻿using Archipelago.MultiClient.Net.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace Stacklands_Randomizer_Mod
+{
+    public static class ItemHandler
+    {
+        /// <summary>
+        /// Handle the creation of idea (blueprint) cards.
+        /// </summary>
+        /// <param name="ideaIds">The card IDs of the idea(s) to be created.</param>
+        public static bool HandleIdeas(List<string> ideaIds)
+        {
+            try
+            {
+                foreach (string id in ideaIds)
+                {
+                    // Create card
+                    WorldManager.instance.CreateCard(
+                        WorldManager.instance.GetRandomSpawnPosition(),
+                        id,
+                        true,
+                        false,
+                        true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to handle Idea(s). Reason: '{ex.Message}'.");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Handle a received item from the Archipelago server.
+        /// </summary>
+        /// <param name="itemInfo">The received <see cref="ItemInfo"/> to be handled.</param>
+        /// <param name="forceCreate">Whether or not this item should be forcefully created.</param>
+        public static void HandleItem(ItemInfo itemInfo, bool forceCreate = false)
+        {
+            if (ItemMapping.Map.SingleOrDefault(m => m.Matches(itemInfo.ItemName)) is Item mappedItem)
+            {
+                HandleItem(mappedItem, itemInfo, forceCreate);
+            }
+            else
+            {
+                Debug.LogError($"Item '{itemInfo.ItemName}' could not be found in the items mapping.");
+            }
+        }
+
+        /// <summary>
+        /// Handle a received item from the Archipelago server by the item name.
+        /// </summary>
+        /// <param name="itemName">The received item name to be handled.</param>
+        /// <param name="sentBy">The player that this item was sent by.</param>
+        /// <param name="forceCreate">Whether or not this item should be forcefully created.</param>
+        public static void HandleItem(string itemName, bool forceCreate = false)
+        {
+            if (ItemMapping.Map.SingleOrDefault(m => m.Matches(itemName)) is Item mappedItem)
+            {
+                HandleItem(mappedItem, null, forceCreate);
+            }
+            else
+            {
+                Debug.LogError($"Item '{itemName}' could not be found in the items mapping.");
+            }
+        }
+
+        /// <summary>
+        /// Handle a received item from the Archipelago server by an <see cref="Item"/> mapping.
+        /// </summary>
+        /// <param name="mappedItem">The received <see cref="Item"/> to be handled.</param>
+        /// <param name="sentBy">The player that this item was sent by.</param>
+        /// <param name="forceCreate">Whether or not this item should be forcefully created.</param>
+        private static void HandleItem(Item mappedItem, ItemInfo? itemInfo, bool forceCreate = false)
+        {
+            Debug.Log($"Handling item '{mappedItem.Name}'...");
+
+            // Get whether item has been handled previously or not
+            bool itemhandled = IsItemHandled(mappedItem);
+
+            // Check if we are in-game
+            if (!StacklandsRandomizer.instance.IsInGame)
+            {
+                Debug.Log($"Not currently in game. Skipping...");
+
+                // Log item (if forcing to create or is unhandled, log it as unhandled)
+                LogItem(mappedItem, !forceCreate && itemhandled);
+                return;
+            }
+
+            // If not forcing to create, check if item has already been handled
+            if (!forceCreate && itemhandled)
+            {
+                Debug.Log($"Item '{mappedItem.Name}' has already been handled. Skipping...");
+                return;
+            }
+
+            switch (mappedItem.ItemType)
+            {
+                case ItemType.BoosterPack:
+                    {
+                        // Log item as handled
+                        LogItem(mappedItem, true);
+
+                        // No need to do anything else, logging it to the logged items is enough.
+                        // IsBoosterPackLogged(...) is called from Patches to unlock boosters.
+                    }
+                    break;
+
+                case ItemType.Idea:
+                    {
+                        // Handle creation of ideas
+                        bool result = HandleIdeas(mappedItem.ItemIds);
+
+                        // Log idea with handled resuly
+                        LogItem(mappedItem, result);
+                    }
+                    break;
+
+                case ItemType.Resource:
+                    {
+                        // Handle creation of resources
+                        bool result = HandleResources(mappedItem.ItemIds);
+
+                        // Log resource with handled result
+                        LogItem(mappedItem, result);
+                    }
+                    break;
+
+                default:
+                    {
+                        Debug.LogError($"Unhandled item type '{mappedItem.ItemType}'");
+
+                        // Log as unhandled
+                        LogItem(mappedItem, false);
+                    }
+                    return;
+            }
+
+            // If not forcefully created and not sent from the current player...
+            if (!forceCreate && itemInfo != null && !itemInfo.Player.Name.Equals(StacklandsRandomizer.instance.PlayerName))
+            {
+                // Display message
+                StacklandsRandomizer.instance.DisplayNotification(
+                    "Item Received!",
+                    $"{mappedItem.Name} was sent to you by {itemInfo.Player.Name} ({itemInfo.LocationName})");
+            }
+        }
+
+        /// <summary>
+        /// Handle the creation of resource cards.
+        /// </summary>
+        /// <param name="ideaIds">The card IDs of the resource(s) to be created.</param>
+        public static bool HandleResources(List<string> ideaIds)
+        {
+            try
+            {
+                // Get a random spawn position
+                Vector3 spawnPosition = WorldManager.instance.GetRandomSpawnPosition();
+
+                foreach (string id in ideaIds)
+                {
+                    // Create card
+                    WorldManager.instance.CreateCard(
+                        spawnPosition,
+                        id,
+                        true,
+                        true, // <-- Add all to stack in same position
+                        true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to handle Idea(s). Reason: '{ex.Message}'.");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Check if a booster pack item has already been logged.
+        /// </summary>
+        /// <param name="boosterId"></param>
+        /// <returns></returns>
+        public static bool IsBoosterPackLogged(string boosterId)
+        {
+            if (ItemMapping.Map.SingleOrDefault(m => m.ItemType == ItemType.BoosterPack && m.ItemIds.Contains(boosterId)) is Item item)
+            {
+                return IsItemHandled(item);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private static bool IsItemHandled(Item item)
+        {
+            return WorldManager.instance.SaveExtraKeyValues.GetWithKey(item.Name) is SerializedKeyValuePair log
+                && Convert.ToBoolean(log.Value);
+        }
+
+        /// <summary>
+        /// Log an item as received from the server.
+        /// </summary>
+        /// <param name="item">The <see cref="Item"/> to be logged.</param>
+        /// <param name="handled">Whether or not this item has been handled.</param>
+        private static void LogItem(Item item, bool handled)
+        {
+            WorldManager.instance.SaveExtraKeyValues
+                .SetOrAdd(item.Name, handled.ToString());
+        }
+    }
+}

--- a/Models/Item.cs
+++ b/Models/Item.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Archipelago.MultiClient.Net.Models;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -20,5 +21,35 @@ namespace Stacklands_Randomizer_Mod
         /// A list of all IDs that this item will unlock.
         /// </summary>
         public List<string> ItemIds { get; set; } = new();
+
+        /// <summary>
+        /// Check if an <see cref="ItemInfo"/> matches this item.
+        /// </summary>
+        /// <param name="item">The <see cref="ItemInfo"/> to be compared.</param>
+        /// <returns><see cref="true"/> if match, <see cref="false"/> if not.</returns>
+        public bool Matches(ItemInfo item)
+        {
+            return this.Matches(item.ItemName);
+        }
+
+        /// <summary>
+        /// Check if an <see cref="Item"/> matches this item.
+        /// </summary>
+        /// <param name="item">The <see cref="Item"/> to be compared.</param>
+        /// <returns><see cref="true"/> if match, <see cref="false"/> if not.</returns>
+        public bool Matches(Item item)
+        {
+            return this.Matches(item.Name);
+        }
+
+        /// <summary>
+        /// Check if an item name matches this item.
+        /// </summary>
+        /// <param name="item">The name to be compared.</param>
+        /// <returns><see cref="true"/> if match, <see cref="false"/> if not.</returns>
+        public bool Matches(string item)
+        {
+            return this.Name.Equals(item, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/Patches/CommonPatchMethods.cs
+++ b/Patches/CommonPatchMethods.cs
@@ -29,6 +29,9 @@ namespace Stacklands_Randomizer_Mod
                 save = SaveGame.LoadFromString("", SaveId);
                 save.DisabledMods = instance.CurrentSave.DisabledMods;
                 save.ExtraKeyValues = instance.CurrentSave.ExtraKeyValues;
+
+                // Save it
+                instance.Save(save);
             }
 
             Debug.Log($"Re-routing to save '{SaveId}'...");

--- a/Patches/QuestManager.cs
+++ b/Patches/QuestManager.cs
@@ -29,7 +29,7 @@ namespace Stacklands_Randomizer_Mod
         [HarmonyPostfix]
         public static void OnBoosterIsUnlocked_UnlockIfReceived(BoosterpackData p, bool allowDebug, ref bool __result)
         {
-            __result = StacklandsRandomizer.instance.IsBoosterPackDiscovered(p.BoosterId);
+            __result = ItemHandler.IsBoosterPackLogged(p.BoosterId);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes
- `ItemHandler` class created to separate all item handling logic from main mod.
- Handled items are now stored in the `SaveGame` instead of the config.
- Tweak to on-screen notifications in both when they display and how they are worded.
  - More information provided such as inclusion of the location name that unlocked an item.