### PR TITLE
FIX: Multi-Check Triggers

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -1072,19 +1072,15 @@ namespace Stacklands_Randomizer_Mod
             Debug.Log($"Simulating quest completion...");
 
             // Get a list of all currently incomplete quests (for mainland)
-            // List<Quest> incompleteQuests = QuestManager.instance.AllQuests
-            //    .Where(q => q.QuestLocation == Location.Mainland && !QuestManager.instance.QuestIsComplete(q))
-            //    .ToList();
+            List<Quest> incompleteQuests = QuestManager.instance.AllQuests
+               .Where(q => q.QuestLocation == Location.Mainland && !QuestManager.instance.QuestIsComplete(q))
+               .ToList();
 
             // Select random quest
-            // Quest quest = incompleteQuests[UnityEngine.Random.Range(0, incompleteQuests.Count)];
+            Quest quest = incompleteQuests[UnityEngine.Random.Range(0, incompleteQuests.Count)];
 
             // Complete a random quest from the list
-            // WorldManager.instance.QuestCompleted(quest);
-            
-            WorldManager.instance.QuestCompleted(AllQuests.CookAnOmelette);
-            WorldManager.instance.QuestCompleted(AllQuests.CookAFrittata);
-            WorldManager.instance.QuestCompleted(AllQuests.CookMeat);
+            WorldManager.instance.QuestCompleted(quest);
         }
 
         #endregion

--- a/Mod.cs
+++ b/Mod.cs
@@ -385,8 +385,8 @@ namespace Stacklands_Randomizer_Mod
                 Quest quest = QuestManager.GetAllQuests()
                     .Find(q => q.Id == questId);
 
-                // Send completed location (but do not show notifications)
-                await SendCompletedLocation(quest);
+                // Add to queue (do not display notifications)
+                await AsyncQueue.Enqueue(() => SendCompletedLocation(quest));
             }
         }
 
@@ -1072,15 +1072,19 @@ namespace Stacklands_Randomizer_Mod
             Debug.Log($"Simulating quest completion...");
 
             // Get a list of all currently incomplete quests (for mainland)
-            List<Quest> incompleteQuests = QuestManager.instance.AllQuests
-                .Where(q => q.QuestLocation == Location.Mainland && !QuestManager.instance.QuestIsComplete(q))
-                .ToList();
+            // List<Quest> incompleteQuests = QuestManager.instance.AllQuests
+            //    .Where(q => q.QuestLocation == Location.Mainland && !QuestManager.instance.QuestIsComplete(q))
+            //    .ToList();
 
             // Select random quest
-            Quest quest = incompleteQuests[UnityEngine.Random.Range(0, incompleteQuests.Count)];
+            // Quest quest = incompleteQuests[UnityEngine.Random.Range(0, incompleteQuests.Count)];
 
             // Complete a random quest from the list
-            WorldManager.instance.QuestCompleted(quest);
+            // WorldManager.instance.QuestCompleted(quest);
+            
+            WorldManager.instance.QuestCompleted(AllQuests.CookAnOmelette);
+            WorldManager.instance.QuestCompleted(AllQuests.CookAFrittata);
+            WorldManager.instance.QuestCompleted(AllQuests.CookMeat);
         }
 
         #endregion

--- a/Patches/WorldManager.cs
+++ b/Patches/WorldManager.cs
@@ -146,7 +146,7 @@ namespace Stacklands_Randomizer_Mod
             Debug.Log($"{nameof(WorldManager)}.{nameof(WorldManager.QuestCompleted)} Prefix!");
             Debug.Log($"Quest completed: {quest.Id}.");
 
-            await StacklandsRandomizer.instance.SendCompletedLocation(quest, true);
+            await AsyncQueue.Enqueue(() => StacklandsRandomizer.instance.SendCompletedLocation(quest, true));
         }
 
         /// <summary>

--- a/Queues/AsyncQueue.cs
+++ b/Queues/AsyncQueue.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stacklands_Randomizer_Mod
+{
+    public static class AsyncQueue
+    {
+        private static object _lock = new object();
+        private static Task _previousTask = Task.CompletedTask;
+
+        private static int _count = 0;
+
+        /// <summary>
+        /// Add an asynchronous task to the queue and perform tasks in order of arrival.
+        /// </summary>
+        /// <param name="task">The asynchronous task to be added to the queue.</param>
+        /// <remarks>
+        /// Logic for this method credited to the author of this blog post: https://zerowidthjoiner.net/2020/10/10/how-to-ensure-tasks-are-executed-serially-fifo
+        /// </remarks>
+        public static async Task Enqueue(Func<Task> task)
+        {
+            Task previousTask;
+            TaskCompletionSource<bool> complete = new TaskCompletionSource<bool>();
+
+            // Lock to ensure order
+            lock (_lock)
+            {
+                // Set the task that precedes this task, if any
+                previousTask = _previousTask;
+                _previousTask = complete.Task;
+
+                // Increment queue count
+                Interlocked.Increment(ref _count);
+            }
+
+            // Wait for previous job to finish
+            await previousTask;
+
+            try
+            {
+                // Perform task
+                await task();
+            }
+            finally
+            {
+                // Set result and decrement from current queue count
+                complete.SetResult(true);
+                Interlocked.Decrement(ref _count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #20 

## Changes
- `AsyncQueue` class created to queue asynchronous methods that waits for previous task to finish before proceeding with FIFO ordering. This should no longer cause a return conflict with `_session.Locations.ScoutLocationsAsync(...)` when multiple quests are completed by the same action. _(Such as `Get a Dog` and `Get Three Villagers` if a dog is the player's third villager)_