### PR TITLE
Various Fixes for v0.0.10

### DIFF
--- a/Handlers/ItemHandler.cs
+++ b/Handlers/ItemHandler.cs
@@ -256,6 +256,11 @@ namespace Stacklands_Randomizer_Mod
                         return IsResourceDiscovered(item.Name);
                     }
 
+                case ItemType.Trap:
+                    {
+                        return IsTrapDiscovered(item.Name);
+                    }
+
                 default:
                     {
                         Debug.LogError($"Unhandled ItemType '{item.ItemType}' in {nameof(IsItemDiscovered)}()");
@@ -293,6 +298,16 @@ namespace Stacklands_Randomizer_Mod
         {
             return WorldManager.instance.SaveExtraKeyValues.GetWithKey(resourceName) is SerializedKeyValuePair kvp
                 && Convert.ToBoolean(kvp.Value);
+        }
+
+        /// <summary>
+        /// Check if a <see cref="Item"/> of type <see cref="ItemType.Trap"/> has been discovered in the current save.
+        /// </summary>
+        /// <param name="resourceName">The name of the <see cref="Item"/> to check.</param>
+        /// <returns><see cref="true"/> if discovered, <see cref="false"/> if not.</returns>
+        public static bool IsTrapDiscovered(string trapName)
+        {
+            return IsResourceDiscovered(trapName);
         }
 
         /// <summary>

--- a/Mappings/ItemMapping.cs
+++ b/Mappings/ItemMapping.cs
@@ -57,6 +57,7 @@ namespace Stacklands_Randomizer_Mod
             new() { Name = "Idea: Magic Tome"           , ItemId = Cards.blueprint_magic_tome           , ItemType = ItemType.Idea },
             new() { Name = "Idea: Magic Wand"           , ItemId = Cards.blueprint_magic_wand           , ItemType = ItemType.Idea },
             new() { Name = "Idea: Market"               , ItemId = Cards.blueprint_market               , ItemType = ItemType.Idea },
+            new() { Name = "Idea: Mess Hall"            , ItemId = Cards.blueprint_mess_hall            , ItemType = ItemType.Idea },
             new() { Name = "Idea: Milkshake"            , ItemId = Cards.blueprint_milkshake            , ItemType = ItemType.Idea },
             new() { Name = "Idea: Omelette"             , ItemId = Cards.blueprint_omelette             , ItemType = ItemType.Idea },
             new() { Name = "Idea: Offspring"            , ItemId = Cards.blueprint_offspring            , ItemType = ItemType.Idea },
@@ -64,7 +65,6 @@ namespace Stacklands_Randomizer_Mod
             new() { Name = "Idea: Plank"                , ItemId = Cards.blueprint_planks               , ItemType = ItemType.Idea },
             new() { Name = "Idea: Quarry"               , ItemId = Cards.blueprint_quarry               , ItemType = ItemType.Idea },
             new() { Name = "Idea: Resource Chest"       , ItemId = Cards.blueprint_resourcechest        , ItemType = ItemType.Idea },
-            new() { Name = "Idea: Resource Magnet"      , ItemId = Cards.blueprint_resource_magnet      , ItemType = ItemType.Idea },
             new() { Name = "Idea: Sawmill"              , ItemId = Cards.blueprint_sawmill              , ItemType = ItemType.Idea },
             new() { Name = "Idea: Shed"                 , ItemId = Cards.blueprint_shed                 , ItemType = ItemType.Idea },
             new() { Name = "Idea: Slingshot"            , ItemId = Cards.blueprint_slingshot            , ItemType = ItemType.Idea },
@@ -102,8 +102,8 @@ namespace Stacklands_Randomizer_Mod
             new() { Name = "Wood x5"            , ItemId = Cards.wood           , ItemType = ItemType.Resource, Amount = 5 },
 
             // Trap Bundles
-            new() { Name = "Get Gooped"         , ItemId = Cards.goop           , ItemType = ItemType.Trap, Amount = 20 },
-            new() { Name = "Get Pooped"         , ItemId = Cards.poop           , ItemType = ItemType.Trap, Amount = 20 },
+            new() { Name = "Get Gooped!"         , ItemId = Cards.goop           , ItemType = ItemType.Trap, Amount = 20 },
+            new() { Name = "Get Pooped!"         , ItemId = Cards.poop           , ItemType = ItemType.Trap, Amount = 20 },
 
             #endregion
 

--- a/Mod.cs
+++ b/Mod.cs
@@ -268,35 +268,36 @@ namespace Stacklands_Randomizer_Mod
             // Test triggers
             if (InputController.instance.GetKeyDown(Key.F5))
             {
-                SimulateItemReceived(ItemType.BoosterPack);
+                //SimulateCreateBooster("idea2");
             }
             else if (InputController.instance.GetKeyDown(Key.F6))
             {
-                SimulateItemReceived(ItemType.Idea);
+                SimulateDeath();
+                //SimulateItemReceived(ItemType.Idea);
             }
             else if (InputController.instance.GetKeyDown(Key.F7))
             {
-                SimulateItemReceived(ItemType.Resource);
+                //SimulateItemReceived(ItemType.Resource);
             }
             else if (InputController.instance.GetKeyDown(Key.F8))
             {
-                SimulateDeath();
+                //SimulateDeath();
             }
             else if (InputController.instance.GetKeyDown(Key.F9))
             {
-                SimulateDeathLinkReceived();
+                //SimulateDeathLinkReceived();
             }
             else if (InputController.instance.GetKeyDown(Key.F10))
             {
-                SimulateQuestComplete();
+                //SimulateQuestComplete();
             }
             else if (InputController.instance.GetKeyDown(Key.F11))
             {
-                SimulateGoalComplete();
+                //SimulateGoalComplete();
             }
             else if (InputController.instance.GetKeyDown(Key.F12))
             {
-                SimulateCreateCard(Cards.corpse);
+                //SimulateCreateCard(Cards.goop);
             }
 
             // Handle next queue actions, if any
@@ -955,9 +956,20 @@ namespace Stacklands_Randomizer_Mod
         #region Testing Methods
 
         /// <summary>
+        /// Simulate a booster pack spawning.
+        /// </summary>
+        /// <param name="packId">The ID of the booster pack</param>
+        private void SimulateCreateBooster(string packId)
+        {
+            WorldManager.instance.CreateBoosterpack(
+                WorldManager.instance.GetRandomSpawnPosition(),
+                packId);
+        }
+
+        /// <summary>
         /// Simulate a card spawning.
         /// </summary>
-        /// <param name="cardId"></param>
+        /// <param name="cardId">The ID of the card.</param>
         private void SimulateCreateCard(string cardId)
         {
             WorldManager.instance.CreateCard(

--- a/Patches/CommonPatchMethods.cs
+++ b/Patches/CommonPatchMethods.cs
@@ -9,18 +9,15 @@ namespace Stacklands_Randomizer_Mod
     {
         // Private Member(s)
         private static readonly List<string> BASIC_CARDS = [
-            Cards.apple,
-            Cards.apple_tree,
             Cards.berrybush,
             Cards.berry,
-            Cards.bone,
-            Cards.carrot,
+            Cards.flint,
             Cards.gold,
-            Cards.goop,
-            Cards.iron_deposit,
             Cards.poop,
             Cards.rock,
-            Cards.tree
+            Cards.soil,
+            Cards.tree,
+            Cards.wood
         ];
 
         private static readonly string PREFIX_SAVE = "ap_";
@@ -74,20 +71,18 @@ namespace Stacklands_Randomizer_Mod
         /// <returns><see cref="true"/> if it should be blocked, <see cref="false"/> if it shouldn't.</returns>
         public static bool ShouldCardBeBlocked(string cardId)
         {
+            Debug.Log($"{nameof(CommonPatchMethods)}.{nameof(ShouldCardBeBlocked)}()");
+
             // Get card data
             CardData cardData = WorldManager.instance.GetCardPrefab(cardId, false);
 
-            // Block if card is from Mainland, is an Idea and has not yet been discovered.
-            return cardData.CardUpdateType switch
-            {
-                // If from Mainland, block if it is an Idea and has not yet been discovered
-                CardUpdateType.Main => cardData.MyCardType is CardType.Ideas && !ItemHandler.IsIdeaDiscovered(cardId),
+            Debug.Log($"Card ID: {cardData.Id}");
+            Debug.Log($"Card Update Type: {cardData.CardUpdateType}");
+            Debug.Log($"Card Type: {cardData.MyCardType}");
 
-                // If from Island, block if it is an Idea and the current goal does not require the island
-                CardUpdateType.Island => cardData.MyCardType is CardType.Ideas && StacklandsRandomizer.instance.CurrentGoal.Type is not GoalType.KillDemonLord,
-
-                _ => false // Don't block all other card update types
-            };
+            // Block card if it exists as a mapped idea and has not yet been discovered
+            return ItemMapping.Map.Exists(m => m.ItemType is ItemType.Idea && m.ItemId == cardId)
+                && !ItemHandler.IsIdeaDiscovered(cardId);
         }
     }
 }

--- a/Patches/WorldManager.cs
+++ b/Patches/WorldManager.cs
@@ -30,7 +30,6 @@ namespace Stacklands_Randomizer_Mod
         /// <summary>
         /// When a save is cleared, re-sync all received items from server.
         /// </summary>
-        /// <param name="__instance"></param>
         [HarmonyPatch(nameof(WorldManager.ClearSaveAndRestart))]
         [HarmonyPostfix]
         public static void OnClearSaveAndRestart_SyncItemsWithServer(WorldManager __instance)
@@ -96,7 +95,7 @@ namespace Stacklands_Randomizer_Mod
                 // If this death was not triggered by a deathlink, send deathlink
                 if (!StacklandsRandomizer.instance.HandlingDeathLink)
                 {
-                    StacklandsRandomizer.instance.SendDeathlink(combatable.name, $"A {combatable.Name} has ceased to be.");
+                    StacklandsRandomizer.instance.SendDeathlink(combatable.Name, $"A {combatable.Name} has ceased to be.");
                 }
 
                 // Set block back to false


### PR DESCRIPTION
## Fixes
- Small selection of ideas from apworld should no longer be able to be received from booster packs. ( fixes #37 )
- `Graveyard` should now be craftable ( fixes #36  )
- `Idea: Resource Magnet` removed from item pool as it is not part of Mainland ( fixes #40 )
- `Idea: Mess Hall` re-instated to item pool as it can be created via Mainland only items.
- Villagers that die should no longer display **Misc_Clone(Type)** in notifications. ( fixes #39 )
- `Get Pooped!` and `Get Gooped!` trap items should now spawn correctly. ( fixes #38 )