### PR TITLE
Various Fixes from v0.0.11

### DIFF
--- a/Configs/manifest.json
+++ b/Configs/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "archipelago_randomizer",
 	"name": "Archipelago Randomizer",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"assembly": "StacklandsRandomizer.dll"
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -270,7 +270,7 @@ namespace Stacklands_Randomizer_Mod
             // Test triggers for development
             if (InputController.instance.GetKeyDown(Key.F5))
             {
-                //SimulateCreateCard(Cards.villager);
+                //SimulateUnlockBooster();
             }
             else if (InputController.instance.GetKeyDown(Key.F6))
             {
@@ -996,6 +996,16 @@ namespace Stacklands_Randomizer_Mod
                 true,
                 false,
                 true);
+        }
+
+        private void SimulateUnlockBooster()
+        {
+            string unfoundBooster = CommonPatchMethods.MAINLAND_PACKS.LastOrDefault(p => !WorldManager.instance.CurrentSave.FoundBoosterIds.Contains(p));
+
+            if (!string.IsNullOrWhiteSpace(unfoundBooster))
+            {
+                ItemHandler.HandleBoosterPack(unfoundBooster);
+            }
         }
 
         /// <summary>

--- a/Mod.cs
+++ b/Mod.cs
@@ -438,36 +438,36 @@ namespace Stacklands_Randomizer_Mod
             // Should we display a notification?
             if (notify) 
             {
-                string title = string.Empty;
+                string title = $"{SokLoc.Translate(QUEST_COMPLETE_LABEL)} ";
                 string message = string.Empty;
 
                 // Was it a location check?
                 if (location != null)
                 {
-                    // Is this quest the goal?
-                    if (location.LocationName.Equals(CurrentGoal.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        title = $"Goal Complete: {location.LocationName}";
-                        message = "Congratulations! Please go to the Mods menu and click 'Send Goal' to complete your run.";
-                    }
                     // Is the receiver of the check this player?
-                    else if (location.IsReceiverRelatedToActivePlayer)
+                    if (location.IsReceiverRelatedToActivePlayer)
                     {
-                        title = $"{SokLoc.Translate(QUEST_COMPLETE_LABEL)} ";
                         message = $"You found your {location.ItemName}\n({location.LocationName})";
                     }
                     // Is the receiver another player?
                     else
                     {
-                        title = $"{SokLoc.Translate(QUEST_COMPLETE_LABEL)} ";
                         message = $"You sent {location.ItemName} to {location.Player.Name}\n({location.LocationName})";
                     }
                 }
                 // If it wasn't...
                 else
                 {
-                    title = $"{SokLoc.Translate(QUEST_COMPLETE_LABEL)} ";
-                    message = $"{quest.Description}";
+                    // Is this quest the goal?
+                    if (quest.Id == CurrentGoal.QuestId)
+                    {
+                        title = $"Goal Completed!";
+                        message = $"Congratulations, you completed '{CurrentGoal.Name}'! Please go to the Mods menu and click 'Send Goal' to complete your run.";
+                    }
+                    else
+                    {
+                        message = $"{quest.Description}";
+                    }
                 }
 
                 // Display the notification

--- a/Mod.cs
+++ b/Mod.cs
@@ -265,15 +265,14 @@ namespace Stacklands_Randomizer_Mod
                 PrepareToConnect();
             }
 
-            // Test triggers
+            // Test triggers for development
             if (InputController.instance.GetKeyDown(Key.F5))
             {
-                //SimulateCreateBooster("idea2");
+                //SimulateCreateCard(Cards.villager);
             }
             else if (InputController.instance.GetKeyDown(Key.F6))
             {
-                SimulateDeath();
-                //SimulateItemReceived(ItemType.Idea);
+                //SimulateCreateBooster("ideas");
             }
             else if (InputController.instance.GetKeyDown(Key.F7))
             {
@@ -981,16 +980,16 @@ namespace Stacklands_Randomizer_Mod
         }
 
         /// <summary>
-        /// Simulate a villager dying and triggering sending a DeathLink (if enabled)
+        /// Simulate a villager dying.
         /// </summary>
-        private void SimulateDeath()
+        private void SimulateDeath(bool deathLink = false)
         {
             Debug.Log($"Simulating villager death...");
-            KillRandomVillager(PlayerName);
+            WorldManager.instance.GetCard<Villager>()?.Die();
         }
 
         /// <summary>
-        /// Simulate a DeathLink received trigger.
+        /// Simulate a villager being killed by a DeathLink trigger.
         /// </summary>
         private void SimulateDeathLinkReceived()
         {

--- a/Mod.cs
+++ b/Mod.cs
@@ -274,7 +274,7 @@ namespace Stacklands_Randomizer_Mod
             }
             else if (InputController.instance.GetKeyDown(Key.F6))
             {
-                SimulateCreateCard(Cards.villager);
+                //SimulateCreateCard(Cards.villager);
             }
             else if (InputController.instance.GetKeyDown(Key.F7))
             {
@@ -286,7 +286,7 @@ namespace Stacklands_Randomizer_Mod
             }
             else if (InputController.instance.GetKeyDown(Key.F9))
             {
-                SimulateDeathLinkReceived();
+                //SimulateDeathLinkReceived();
             }
             else if (InputController.instance.GetKeyDown(Key.F10))
             {

--- a/Patches/CardBag.cs
+++ b/Patches/CardBag.cs
@@ -9,20 +9,22 @@ namespace Stacklands_Randomizer_Mod
     public class CardBag_Patches
     {
         /// <summary>
-        /// Replace blueprints with basic cards.
+        /// Replace blueprints in card bags with basic cards.
         /// </summary>
         [HarmonyPatch(nameof(CardBag.GetCardsInBag), [typeof(GameDataLoader)])]
         [HarmonyPostfix]
         public static void OnGetCardsInBag_ReplaceBlueprints(ref GameDataLoader loader, ref List<string> __result)
         {
-            List<string> toReplace = __result
-                .Where(c => CommonPatchMethods.ShouldCardBeBlocked(c))
-                .ToList();
+            // Remove all cards that need to be blocked
+            __result.RemoveAll(c => CommonPatchMethods.ShouldCardBeBlocked(c));
 
-            foreach (string card in toReplace)
+            // Add all basic cards
+            foreach (string card in CommonPatchMethods.BASIC_CARDS)
             {
-                // Swap blueprint ID with a basic card ID
-                __result[__result.IndexOf(card)] = CommonPatchMethods.GetRandomBasicCard();
+                if (!__result.Contains(card))
+                {
+                    __result.Add(card);
+                }
             }
         }
 

--- a/Patches/CommonPatchMethods.cs
+++ b/Patches/CommonPatchMethods.cs
@@ -8,7 +8,7 @@ namespace Stacklands_Randomizer_Mod
     public static class CommonPatchMethods
     {
         // Private Member(s)
-        private static readonly List<string> BASIC_CARDS = [
+        public static readonly List<string> BASIC_CARDS = [
             Cards.berrybush,
             Cards.berry,
             Cards.flint,
@@ -71,9 +71,6 @@ namespace Stacklands_Randomizer_Mod
         /// <returns><see cref="true"/> if it should be blocked, <see cref="false"/> if it shouldn't.</returns>
         public static bool ShouldCardBeBlocked(string cardId)
         {
-            // Get card data
-            CardData cardData = WorldManager.instance.GetCardPrefab(cardId, false);
-
             // Block card if it exists as a mapped idea and has not yet been discovered
             return ItemMapping.Map.Exists(m => m.ItemType is ItemType.Idea && m.ItemId == cardId)
                 && !ItemHandler.IsIdeaDiscovered(cardId);
@@ -86,7 +83,7 @@ namespace Stacklands_Randomizer_Mod
         /// <returns><see cref="true"/> if it should be blocked, <see cref="false"/> if it shouldn't.</returns>
         public static bool ShouldBoosterPackBeBlocked(string boosterId)
         {
-            return boosterId == "new_weaponry";
+            return boosterId == "combat_intro";
         }
     }
 }

--- a/Patches/CommonPatchMethods.cs
+++ b/Patches/CommonPatchMethods.cs
@@ -71,18 +71,22 @@ namespace Stacklands_Randomizer_Mod
         /// <returns><see cref="true"/> if it should be blocked, <see cref="false"/> if it shouldn't.</returns>
         public static bool ShouldCardBeBlocked(string cardId)
         {
-            Debug.Log($"{nameof(CommonPatchMethods)}.{nameof(ShouldCardBeBlocked)}()");
-
             // Get card data
             CardData cardData = WorldManager.instance.GetCardPrefab(cardId, false);
-
-            Debug.Log($"Card ID: {cardData.Id}");
-            Debug.Log($"Card Update Type: {cardData.CardUpdateType}");
-            Debug.Log($"Card Type: {cardData.MyCardType}");
 
             // Block card if it exists as a mapped idea and has not yet been discovered
             return ItemMapping.Map.Exists(m => m.ItemType is ItemType.Idea && m.ItemId == cardId)
                 && !ItemHandler.IsIdeaDiscovered(cardId);
+        }
+
+        /// <summary>
+        /// Check whether a booster pack should be blocked from spawning.
+        /// </summary>
+        /// <param name="boosterId">The ID of the booster pack to check.</param>
+        /// <returns><see cref="true"/> if it should be blocked, <see cref="false"/> if it shouldn't.</returns>
+        public static bool ShouldBoosterPackBeBlocked(string boosterId)
+        {
+            return boosterId == "new_weaponry";
         }
     }
 }

--- a/Patches/QuestManager.cs
+++ b/Patches/QuestManager.cs
@@ -30,6 +30,18 @@ namespace Stacklands_Randomizer_Mod
         public static void OnBoosterIsUnlocked_UnlockIfReceived(BoosterpackData p, bool allowDebug, ref bool __result)
         {
             __result = ItemHandler.IsBoosterPackDiscovered(p.BoosterId);
+
+            // If booster has been unlocked...
+            if (__result)
+            {
+                // If not yet completed 'Unlock All Packs' quest and all mainland packs have been discovered, trigger special action for quest.
+                if (!WorldManager.instance.CurrentSave.CompletedAchievementIds.Contains(AllQuests.UnlockAllPacks.Id) && WorldManager.instance.CurrentSave.FoundBoosterIds.ContainsAll(CommonPatchMethods.MAINLAND_PACKS))
+                {
+                    QuestManager.instance.SpecialActionComplete("unlocked_all_packs");
+                }
+
+                // All Island Packs quest will go here when Island is supported
+            }
         }
 
         /// <summary>

--- a/Patches/WorldManager.cs
+++ b/Patches/WorldManager.cs
@@ -41,29 +41,16 @@ namespace Stacklands_Randomizer_Mod
         }
 
         /// <summary>
-        /// When a booster pack is created, intercept the creation of specific ones such as the 'New Weaponry' pack.
-        /// </summary>
-        [HarmonyPatch(nameof(WorldManager.CreateBoosterpack))]
-        [HarmonyPrefix]
-        public static bool OnCreateBoosterPack_Intercept(WorldManager __instance, ref string boosterId)
-        {
-            Debug.Log($"{nameof(WorldManager)}.{nameof(WorldManager.CreateBoosterpack)} Prefix!");
-            Debug.Log($"Creating Booster Pack with ID: {boosterId}");
-
-            return !CommonPatchMethods.ShouldBoosterPackBeBlocked(boosterId);
-        }
-
-        /// <summary>
         /// When a card is created, remove blueprints from equipable items to prevent mobs from dropping them too early.
         /// </summary>
-        [HarmonyPatch(nameof(WorldManager.CreateCard))]
+        [HarmonyPatch(nameof(WorldManager.CreateCard), [typeof(Vector3), typeof(CardData), typeof(bool), typeof(bool), typeof(bool), typeof(bool)])]
         [HarmonyPrefix]
         public static void OnCreateCard_Intercept(WorldManager __instance, ref CardData cardDataPrefab)
         {
             Debug.Log($"{nameof(WorldManager)}.{nameof(WorldManager.CreateCard)} Prefix!");
             Debug.Log($"Creating Card with ID: {cardDataPrefab.Id}");
 
-            if (cardDataPrefab is Equipable equipable)
+            if (cardDataPrefab is Equipable equipable && equipable.blueprint != null)
             {
                 equipable.blueprint = null;
             }
@@ -154,6 +141,12 @@ namespace Stacklands_Randomizer_Mod
         public static async void OnPlay_SyncLocations(WorldManager __instance)
         {
             Debug.Log($"{nameof(WorldManager)}.{nameof(WorldManager.Play)} Postfix!");
+
+            // Add 'combat intro' to found booster packs to prevent it from spawning
+            if (!__instance.CurrentSave.FoundBoosterIds.Contains("combat_intro"))
+            {
+                __instance.CurrentSave.FoundBoosterIds.Add("combat_intro");
+            }
 
             // Send all currently completed locations
             await StacklandsRandomizer.instance.SendAllCompletedLocations();

--- a/Patches/WorldManager.cs
+++ b/Patches/WorldManager.cs
@@ -41,6 +41,35 @@ namespace Stacklands_Randomizer_Mod
         }
 
         /// <summary>
+        /// When a booster pack is created, intercept the creation of specific ones such as the 'New Weaponry' pack.
+        /// </summary>
+        [HarmonyPatch(nameof(WorldManager.CreateBoosterpack))]
+        [HarmonyPrefix]
+        public static bool OnCreateBoosterPack_Intercept(WorldManager __instance, ref string boosterId)
+        {
+            Debug.Log($"{nameof(WorldManager)}.{nameof(WorldManager.CreateBoosterpack)} Prefix!");
+            Debug.Log($"Creating Booster Pack with ID: {boosterId}");
+
+            return !CommonPatchMethods.ShouldBoosterPackBeBlocked(boosterId);
+        }
+
+        /// <summary>
+        /// When a card is created, remove blueprints from equipable items to prevent mobs from dropping them too early.
+        /// </summary>
+        [HarmonyPatch(nameof(WorldManager.CreateCard))]
+        [HarmonyPrefix]
+        public static void OnCreateCard_Intercept(WorldManager __instance, ref CardData cardDataPrefab)
+        {
+            Debug.Log($"{nameof(WorldManager)}.{nameof(WorldManager.CreateCard)} Prefix!");
+            Debug.Log($"Creating Card with ID: {cardDataPrefab.Id}");
+
+            if (cardDataPrefab is Equipable equipable)
+            {
+                equipable.blueprint = null;
+            }
+        }
+
+        /// <summary>
         /// When receiving a random card, replace blueprints with a basic card.
         /// </summary>
         [HarmonyPatch(nameof(WorldManager.GetRandomCard))]


### PR DESCRIPTION
## Fixes
- Fixes #4 to prevent 'Unlock All Packs' quest from firing when `Order and Structure` pack is unlocked and now triggers when all Mainland booster packs have been unlocked.
- Fixes #44 to ensure `Catacombs` and `Forest` now drop items when explored.
- Fixes #43 to ensure goal completion message now appears when the goal is completed.
- Fixes #17 to prevent the game state from locking the player when a received DeathLink trigger kills a villager while a cutscene is in progress.
- Fixes #28 to prevent the `New Weaponry` booster pack from spawning as it would give equipment blueprints too early.
- Fixes #15 to prevent enemies dropping blueprints for equipment too early _(but will still drop the equipment item itself)_
- Fixes #41 to prevent the pack details from rapidly changing every frame when a booster pack is hovered over.