### PR TITLE
Merge v0.1.4 alpha

### DIFF
--- a/Configs/manifest.json
+++ b/Configs/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "archipelago_randomizer",
 	"name": "Archipelago Randomizer",
-	"version": "0.1.3-alpha",
+	"version": "0.1.4-alpha",
 	"assembly": "StacklandsRandomizer.dll"
 }

--- a/Constants/UnsupportedQuests.cs
+++ b/Constants/UnsupportedQuests.cs
@@ -17,6 +17,9 @@ namespace Stacklands_Randomizer_Mod.Constants
             AllQuests.KillDemonLord.Id,                  // Kill the Demon Lord
             AllQuests.CreateAltar.Id,                    // Talk to the Shaman to gain secret knowledge
             AllQuests.CitiesGetBar.Id,                   // Smelt some Ore
+            AllQuests.BreakBottle.Id,                    // Break a Bottle
+            AllQuests.WearCrabScaleArmor.Id,             // Make a Villager Wear Crab Scale Armor
+            AllQuests.CraftAmuletForest.Id               // Craft the Amulet of the Forest
         ];
     }
 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -267,7 +267,7 @@ namespace Stacklands_Randomizer_Mod
             // Test triggers for development
             if (InputController.instance.GetKeyDown(Key.F5))
             {
-                //SimulateUnlockBooster();
+                //SimulateCreateCard(Cards.villager);
             }
             else if (InputController.instance.GetKeyDown(Key.F6))
             {
@@ -287,7 +287,7 @@ namespace Stacklands_Randomizer_Mod
             }
             else if (InputController.instance.GetKeyDown(Key.F10))
             {
-                //SimulateQuestComplete();
+                //SimulateQuestComplete(AllQuests.FinishFirstWave);
             }
             else if (InputController.instance.GetKeyDown(Key.F11))
             {
@@ -1153,6 +1153,17 @@ namespace Stacklands_Randomizer_Mod
 
             // Complete a random quest from the list
             WorldManager.instance.QuestCompleted(quest);
+        }
+
+        /// <summary>
+        /// Simulate a specific special action.
+        /// </summary>
+        private void SimulateSpecialAction(string specialAction)
+        {
+            Debug.Log($"Simulating special action '{specialAction}'...");
+            
+            // Trigger special action
+            QuestManager.instance.SpecialActionComplete(specialAction);
         }
 
         #endregion

--- a/Patches/WorldManager.cs
+++ b/Patches/WorldManager.cs
@@ -76,6 +76,22 @@ namespace Stacklands_Randomizer_Mod
         }
 
         /// <summary>
+        /// When checking if a card has been found, intercept specific card checks
+        /// </summary>
+        [HarmonyPatch(nameof(WorldManager.HasFoundCard))]
+        [HarmonyPostfix]
+        public static void OnHasFoundCard_Intercept(WorldManager __instance, ref string cardId, ref bool __result)
+        {
+            // If dark forest enabled in checks, pretend that Idea: Stable Portal has been found to prevent it automatically spawning when returning from The Dark Forest
+            if (cardId == Cards.blueprint_stable_portal && StacklandsRandomizer.instance.DarkForestEnabled)
+            {
+                __result = true;
+            }
+
+            // Other intercepts here, if needed
+        }
+
+        /// <summary>
         /// When the pause menu is showing, override the 'IsPlaying' property (if required) to ensure time continues.
         /// </summary>
         [HarmonyPatch(nameof(WorldManager.IsPlaying), MethodType.Getter)]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quest completions remain the same as the base game, but the order in which they 
 ### Items
 **Progression** 
 - Booster Packs
-- Ideas _(AKA 'Blueprints')_ for items required to complete Quests such as `Plank`, `Quarry`, `Smithy`, `Temple` etc.
+- Ideas _(AKA 'Blueprints')_ for items required to complete Quests such as `Plank`, `Quarry`, `Smithy`, `Temple` etc. 
 **Useful** 
 - Ideas _(AKA 'Blueprints')_ for items that help make the run easier but don't impact progression such as `Coin Chest`, `Hammer`, `Warehouse` etc.
 **Filler / Junk**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@ A mod for Stacklands that allows it to be integrated into an Archipelago world.
 This repo was forked from and is a continuation of the development of the original mod: [chandler05/Stacklands-Randomizer](https://github.com/chandler05/Stacklands-Randomizer)
 
 ## How it Works
-In each run, all quests are checks and all Booster Packs and Ideas are items received from checks.
+In an archipelago run of Stacklands, you will be completing the in-game quests to complete Location Checks and items received will be Ideas _(AKA 'Blueprints')_ to make craftable items.
+Quest completions remain the same as the base game, but the order in which they can be completed will depend on the randomisation of the ideas received.
+
+### Locations
+- 'Mainland' Quests
+- 'The Dark Forest' Quests _(toggled on/off in YAML)_
+- Mobsanity _(killing one of each enemy type - toggled on/off in YAML)_
+
+### Items
+**Progression** 
+- Booster Packs
+- Ideas _(AKA 'Blueprints')_ for items required to complete Quests such as `Plank`, `Quarry`, `Smithy`, `Temple` etc.
+**Useful** 
+- Ideas _(AKA 'Blueprints')_ for items that help make the run easier but don't impact progression such as `Coin Chest`, `Hammer`, `Warehouse` etc.
+**Filler / Junk**
+- Food and Material resources such as ``
+**Traps**
+- Enemy Spawns
+- Flood of useless items worth 0 coins
+- _(More to be added soon...)_
 
 ### Current Support
 - Mainland _(full support)_

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ The items available in this AP randomizer are:
 - Booster Packs
 - Ideas _(AKA 'Blueprints')_ for items required to complete Quests such as `Plank`, `Quarry`, `Smithy`, `Temple` etc. 
 
-- **Useful** 
+**Useful** 
 - Ideas _(AKA 'Blueprints')_ for items that help make the run easier but don't impact progression such as `Coin Chest`, `Hammer`, `Warehouse` etc.
 
-- **Filler / Junk**
+**Filler / Junk**
 - Food and Material resources such as `Apple`, `Wood`, `Coin` etc.
 
-- **Traps**
+**Traps**
 - Enemy Spawns
 - Flood of useless items worth 0 coins
 - _(More to be added soon...)_

--- a/README.md
+++ b/README.md
@@ -8,19 +8,26 @@ In an archipelago run of Stacklands, you will be completing the in-game quests t
 Quest completions remain the same as the base game, but the order in which they can be completed will depend on the randomisation of the ideas received.
 
 ### Locations
+The locations available in this AP randomizer are:
+
 - 'Mainland' Quests
 - 'The Dark Forest' Quests _(toggled on/off in YAML)_
 - Mobsanity _(killing one of each enemy type - toggled on/off in YAML)_
 
 ### Items
+The items available in this AP randomizer are:
+
 **Progression** 
 - Booster Packs
 - Ideas _(AKA 'Blueprints')_ for items required to complete Quests such as `Plank`, `Quarry`, `Smithy`, `Temple` etc. 
-**Useful** 
+
+- **Useful** 
 - Ideas _(AKA 'Blueprints')_ for items that help make the run easier but don't impact progression such as `Coin Chest`, `Hammer`, `Warehouse` etc.
-**Filler / Junk**
-- Food and Material resources such as ``
-**Traps**
+
+- **Filler / Junk**
+- Food and Material resources such as `Apple`, `Wood`, `Coin` etc.
+
+- **Traps**
 - Enemy Spawns
 - Flood of useless items worth 0 coins
 - _(More to be added soon...)_


### PR DESCRIPTION
## Fixes
- Irrelevant quests in `Strengthen Up` category should no longer appear in the quest list.
- The `Idea: Stable Portal` should no longer spawn when leaving The Dark Forest, to prevent it being received before receiving it as an AP item. If the dark forest is disabled in the YAML, it should spawn as normal.